### PR TITLE
Update bindgen to 0.49.2 to support BINDGEN_EXTRA_CLANG_ARGS for fixing cross compilation.

### DIFF
--- a/snap7-sys/Cargo.toml
+++ b/snap7-sys/Cargo.toml
@@ -11,7 +11,7 @@ keywords    = ["HAL", "PLC", "S7"]
 build       = "build.rs"
 
 [build-dependencies]
-bindgen = "0.37"
+bindgen = "0.49.2"
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
https://github.com/rust-lang/rust-bindgen/issues/1229